### PR TITLE
Add Docker 19.03.14 and 20.10.0

### DIFF
--- a/d/docker-19.03.14.yml
+++ b/d/docker-19.03.14.yml
@@ -1,0 +1,21 @@
+docker:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-docker:19.03.14${SUFFIX}
+  command: ros user-docker
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  net: host
+  pid: host
+  ipc: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes_from:
+  - all-volumes
+  volumes:
+  - /sys:/host/sys
+  - /var/lib/system-docker:/var/lib/system-docker:shared

--- a/d/docker-20.10.0.yml
+++ b/d/docker-20.10.0.yml
@@ -1,0 +1,21 @@
+docker:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-docker:20.10.0${SUFFIX}
+  command: ros user-docker
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  net: host
+  pid: host
+  ipc: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes_from:
+  - all-volumes
+  volumes:
+  - /sys:/host/sys
+  - /var/lib/system-docker:/var/lib/system-docker:shared

--- a/images/10-docker-19.03.14/Dockerfile
+++ b/images/10-docker-19.03.14/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-19.03.14/prebuild.sh
+++ b/images/10-docker-19.03.14/prebuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "amd64" ]; then
+    DOCKERARCH="x86_64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-19.03.14_arm64/Dockerfile
+++ b/images/10-docker-19.03.14_arm64/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-19.03.14_arm64/prebuild.sh
+++ b/images/10-docker-19.03.14_arm64/prebuild.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "arm64" ]; then
+    DOCKERARCH="aarch64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+    SUFFIX="_${ARCH}"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-20.10.0/Dockerfile
+++ b/images/10-docker-20.10.0/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-20.10.0/prebuild.sh
+++ b/images/10-docker-20.10.0/prebuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "amd64" ]; then
+    DOCKERARCH="x86_64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-20.10.0_arm64/Dockerfile
+++ b/images/10-docker-20.10.0_arm64/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-20.10.0_arm64/prebuild.sh
+++ b/images/10-docker-20.10.0_arm64/prebuild.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "arm64" ]; then
+    DOCKERARCH="aarch64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+    SUFFIX="_${ARCH}"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/index.yml
+++ b/index.yml
@@ -19,3 +19,4 @@ services:
 engines:
 - docker-19.03.13
 - docker-19.03.14
+- docker-20.10.0

--- a/index.yml
+++ b/index.yml
@@ -18,3 +18,4 @@ services:
 - docker-compose
 engines:
 - docker-19.03.13
+- docker-19.03.14


### PR DESCRIPTION
Add Docker [19.03.14](https://github.com/moby/moby/releases/tag/v19.03.14) and [20.10.0](https://github.com/moby/moby/releases/tag/v20.10.0)

Those have already built and can be tested on 1.9.0-rc1 with commands:
```bash
sudo ros engine list --update
sudo ros engine switch docker-19.03.14
sudo ros engine switch docker-20.10.0
```

This PR will add those to coming release version branch on official way.