### PR TITLE
Build hyperv-vmtool and vbox-tool with kernel 4.14.211-burmilla

### DIFF
--- a/h/hyperv-vm-tools.yml
+++ b/h/hyperv-vm-tools.yml
@@ -1,5 +1,5 @@
 hyperv-vm-tools:
-  image: ${REGISTRY_DOMAIN}/burmilla/os-hypervvmtools:v4.14.206-burmilla-1
+  image: ${REGISTRY_DOMAIN}/burmilla/os-hypervvmtools:v4.14.211-burmilla
   command: ["hv_kvp_daemon", "-n"]
   privileged: true
   labels:

--- a/images/10-hypervvmtools/Dockerfile
+++ b/images/10-hypervvmtools/Dockerfile
@@ -6,7 +6,7 @@ FROM gcc:7.4.0 as build-essential
 #    rm -rf /var/lib/apt/* \
 
 WORKDIR /dist
-ENV KERNEL_VERSION 4.14.206-burmilla
+ENV KERNEL_VERSION 4.14.211-burmilla
 ENV KERNEL_SRC https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86-src.tgz
 
 RUN wget -q $KERNEL_SRC && \

--- a/images/10-vboxtools/Dockerfile
+++ b/images/10-vboxtools/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcc:7.4.0 as build-essential
-ENV KERNEL_VERSION 4.14.206-burmilla
+ENV KERNEL_VERSION 4.14.211-burmilla
 
 ENV KERNEL_HEADERS https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/build-linux-${KERNEL_VERSION}-x86.tar.gz
 ENV KERNEL_BASE https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz

--- a/v/virtualbox-tools.yml
+++ b/v/virtualbox-tools.yml
@@ -1,5 +1,5 @@
 virtualbox-tools:
-  image: ${REGISTRY_DOMAIN}/burmilla/os-vboxtools:v6.1.16-4.14.206-burmilla
+  image: ${REGISTRY_DOMAIN}/burmilla/os-vboxtools:v6.1.16-4.14.211-burmilla
   command: /usr/local/bin/run
   privileged: true
   restart: always


### PR DESCRIPTION
It looks to be that Hyper-V and VirtualBox tools must match to exact kernel version.