### PR TITLE
Correct parameters for NFS and CIFS services

### DIFF
--- a/images/20-volumenetshare/Dockerfile
+++ b/images/20-volumenetshare/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 
 ARG netshare_plugin_version=0.36
 
-RUN apk add --update wget nfs-utils ca-certificates &&\
+RUN apk add --update wget cifs-utils nfs-utils ca-certificates &&\
     rm -rf /var/cache/apk/* &&\
     update-ca-certificates
 

--- a/v/volume-cifs.yml
+++ b/v/volume-cifs.yml
@@ -8,6 +8,7 @@ volume-cifs:
   privileged: true
   restart: always
   volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
     - /run/docker/plugins:/run/docker/plugins:rw
     - /mnt/volumes/netshare/cifs:/mnt/volumes/netshare/cifs:shared
   labels:

--- a/v/volume-efs.yml
+++ b/v/volume-efs.yml
@@ -8,6 +8,7 @@ volume-efs:
   privileged: true
   restart: always
   volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
     - /run/docker/plugins:/run/docker/plugins:rw
     - /mnt/volumes/netshare/efs:/mnt:shared
   labels:

--- a/v/volume-nfs.yml
+++ b/v/volume-nfs.yml
@@ -8,8 +8,9 @@ volume-nfs:
   privileged: true
   restart: always
   volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
     - /run/docker/plugins:/run/docker/plugins:rw
-    - /mnt/volumes/netshare/nfs:/mnt:shared
+    - /mnt/nfs:/mnt/nfs:shared
   labels:
     io.rancher.os.scope: system
     io.rancher.os.after: docker


### PR DESCRIPTION
Found during https://github.com/burmilla/os/issues/40 debugging that new NFS and CIFS parameters need to be updated a little bit before before latest version of https://github.com/ContainX/docker-volume-netshare works correctly.

EFS is most probably also broken but it cannot be tested outside of AWS so let's handle it on later PRs if someone reports that they need it.