### PR TITLE
Add Docker 20.10.2 to v1.9.0

### DIFF
--- a/d/docker-20.10.2.yml
+++ b/d/docker-20.10.2.yml
@@ -1,0 +1,21 @@
+docker:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-docker:20.10.2${SUFFIX}
+  command: ros user-docker
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  net: host
+  pid: host
+  ipc: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes_from:
+  - all-volumes
+  volumes:
+  - /sys:/host/sys
+  - /var/lib/system-docker:/var/lib/system-docker:shared

--- a/images/10-docker-20.10.2/Dockerfile
+++ b/images/10-docker-20.10.2/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-20.10.2/prebuild.sh
+++ b/images/10-docker-20.10.2/prebuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "amd64" ]; then
+    DOCKERARCH="x86_64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-20.10.2_arm64/Dockerfile
+++ b/images/10-docker-20.10.2_arm64/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-20.10.2_arm64/prebuild.sh
+++ b/images/10-docker-20.10.2_arm64/prebuild.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "arm64" ]; then
+    DOCKERARCH="aarch64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+    SUFFIX="_${ARCH}"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/index.yml
+++ b/index.yml
@@ -21,3 +21,4 @@ engines:
 - docker-19.03.14
 - docker-20.10.0
 - docker-20.10.1
+- docker-20.10.2


### PR DESCRIPTION
Docker 20.10.2 is released. Release notes is available on https://docs.docker.com/engine/release-notes/#20102

I already pushed it to master branch which triggered build https://github.com/burmilla/os-services/commit/5ed1153bce956b31a8cef822f75717f3aa8eb4e7 so this PR will just make it visible to v1.9.0 version.