### PR TITLE
Update ZFS

### DIFF
--- a/images/20-zfs/Dockerfile
+++ b/images/20-zfs/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcc:7.4.0
-# FROM arm64=arm64v8/gcc:7.4.0
+FROM gcc:10
+# FROM arm64=arm64v8/gcc:10
 
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends \

--- a/images/20-zfs/Dockerfile.zfs-tools
+++ b/images/20-zfs/Dockerfile.zfs-tools
@@ -1,5 +1,5 @@
-FROM ubuntu:bionic
-# FROM arm64=arm64v8/ubuntu:bionic
+FROM ubuntu:focal
+# FROM arm64=arm64v8/ubuntu:focal
 
 RUN apt-get update \
     && apt-get install -yq python \
@@ -19,16 +19,18 @@ ADD lib/udev/rules.d/69-vdev.rules /lib/udev/rules.d/69-vdev.rules
 ADD lib/udev/rules.d/90-zfs.rules /lib/udev/rules.d/90-zfs.rules
 
 # fix build warnings
-RUN mv /usr/local/lib/libnvpair.so.1 /usr/local/lib/libnvpair.so.1.file
-RUN ln -s /usr/local/lib/libnvpair.so.1.file /usr/local/lib/libnvpair.so.1
-RUN mv /usr/local/lib/libzfs_core.so.1 /usr/local/lib/libzfs_core.so.1.file
-RUN ln -s /usr/local/lib/libzfs_core.so.1.file /usr/local/lib/libzfs_core.so.1
-RUN mv /usr/local/lib/libuutil.so.1 /usr/local/lib/libuutil.so.1.file
-RUN ln -s /usr/local/lib/libuutil.so.1.file /usr/local/lib/libuutil.so.1
-RUN mv /usr/local/lib/libzfs.so.2 /usr/local/lib/libzfs.so.2.file
-RUN ln -s /usr/local/lib/libzfs.so.2.file /usr/local/lib/libzfs.so.2
-RUN mv /usr/local/lib/libzpool.so.2 /usr/local/lib/libzpool.so.2.file
-RUN ln -s /usr/local/lib/libzpool.so.2.file /usr/local/lib/libzpool.so.2
+RUN mv /usr/local/lib/libnvpair.so.3 /usr/local/lib/libnvpair.so.3.file
+RUN ln -s /usr/local/lib/libnvpair.so.3.file /usr/local/lib/libnvpair.so.3
+RUN mv /usr/local/lib/libzfs_core.so.3 /usr/local/lib/libzfs_core.so.3.file
+RUN ln -s /usr/local/lib/libzfs_core.so.3.file /usr/local/lib/libzfs_core.so.3
+RUN mv /usr/local/lib/libuutil.so.3 /usr/local/lib/libuutil.so.3.file
+RUN ln -s /usr/local/lib/libuutil.so.3.file /usr/local/lib/libuutil.so.3
+RUN mv /usr/local/lib/libzfs.so.4 /usr/local/lib/libzfs.so.4.file
+RUN ln -s /usr/local/lib/libzfs.so.4.file /usr/local/lib/libzfs.so.4
+RUN mv /usr/local/lib/libzpool.so.4 /usr/local/lib/libzpool.so.4.file
+RUN ln -s /usr/local/lib/libzpool.so.4.file /usr/local/lib/libzpool.so.4
+RUN mv /usr/local/lib/libzfsbootenv.so.1 /usr/local/lib/libzfsbootenv.so.1.file
+RUN ln -s /usr/local/lib/libzfsbootenv.so.1.file /usr/local/lib/libzfsbootenv.so.1
 
 ENV PATH=$PATH:/usr/local/lib
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib

--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -31,11 +31,8 @@ ros service up kernel-headers-system-docker
 
 
 # get the zfs source as per https://github.com/zfsonlinux/zfs/wiki/Building-ZFS
-VERSION="0.7.13"
-curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/spl-${VERSION}.tar.gz > spl-${VERSION}.tar.gz
+VERSION="2.0.1"
 curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/zfs-${VERSION}.tar.gz > zfs-${VERSION}.tar.gz
-mkdir -p spl
-tar zxvf spl-${VERSION}.tar.gz --strip-components=1 -C spl
 mkdir -p zfs
 tar zxvf zfs-${VERSION}.tar.gz --strip-components=1 -C zfs
 
@@ -81,12 +78,6 @@ tar zxvf zfs-${VERSION}.tar.gz --strip-components=1 -C zfs
 
 
 #   --prefix=/dist
-cd /dist/spl
-sh ./autogen.sh
-./configure \
-          --with-linux=${DIR}
-make -s -j$(nproc)
-
 cd /dist/zfs
 sh ./autogen.sh
 ./configure \
@@ -94,8 +85,6 @@ sh ./autogen.sh
 make -s -j$(nproc)
 
 # last layer - we could use stratos :)
-cd /dist/spl
-make DESTDIR=/dist/arch install
 cd /dist/zfs
 make DESTDIR=/dist/arch install
 cd /dist

--- a/z/zfs.yml
+++ b/z/zfs.yml
@@ -1,5 +1,5 @@
 zfs:
-  image: ${REGISTRY_DOMAIN}/burmilla/os-zfs:v0.7.13-1${SUFFIX}
+  image: ${REGISTRY_DOMAIN}/burmilla/os-zfs:v2.0.1-1${SUFFIX}
   command: ./build.sh
   privileged: "true"
   labels:


### PR DESCRIPTION
SPL is now packaged in the zfs tar so this commit also removes some SPL compilation stuff.
Use Ubuntu Focal as base for zfs-tools. Bump GCC to version 10.