### PR TITLE
Add Docker 19.03.15 and 20.10.3 + docker-compose 1.28.2 to v1.9.0

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,7 +17,6 @@ jobs:
       run: |
         export DOCKER_VERSION=1.10.3
         export IMAGE_BUILD_NAME="10-docker-*"
-        make
         make release
 
     - name: Log into registry

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -25,7 +25,6 @@ jobs:
         export DOCKER_VERSION=1.10.3
         export IMAGE_BUILD_NAME=${{ github.event.inputs.image_build_name }}
         export VERSION=${{ github.event.inputs.version }}
-        make
         make release
 
     - name: Log into registry

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -55,7 +55,7 @@ RUN curl -fL ${!DOCKER_URL} > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 
 # Install dapper
-RUN curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m | sed 's/arm.*/arm/'` > /usr/bin/dapper && \
+RUN curl -sL https://releases.rancher.com/dapper/v0.5.4/dapper-`uname -s`-`uname -m | sed 's/arm.*/arm/'` > /usr/bin/dapper && \
     chmod +x /usr/bin/dapper
 
 ENTRYPOINT ["./scripts/entry"]

--- a/d/docker-19.03.15.yml
+++ b/d/docker-19.03.15.yml
@@ -1,0 +1,21 @@
+docker:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-docker:19.03.15${SUFFIX}
+  command: ros user-docker
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  net: host
+  pid: host
+  ipc: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes_from:
+  - all-volumes
+  volumes:
+  - /sys:/host/sys
+  - /var/lib/system-docker:/var/lib/system-docker:shared

--- a/d/docker-20.10.3.yml
+++ b/d/docker-20.10.3.yml
@@ -1,0 +1,21 @@
+docker:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-docker:20.10.3${SUFFIX}
+  command: ros user-docker
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  net: host
+  pid: host
+  ipc: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes_from:
+  - all-volumes
+  volumes:
+  - /sys:/host/sys
+  - /var/lib/system-docker:/var/lib/system-docker:shared

--- a/d/docker-compose.yml
+++ b/d/docker-compose.yml
@@ -1,5 +1,5 @@
 docker-compose:
-  image: ${REGISTRY_DOMAIN}/burmilla/os-dockercompose:1.28.0
+  image: ${REGISTRY_DOMAIN}/burmilla/os-dockercompose:1.28.2
   labels:
     io.rancher.os.scope: system
     io.rancher.os.after: console

--- a/d/docker-compose.yml
+++ b/d/docker-compose.yml
@@ -1,5 +1,5 @@
 docker-compose:
-  image: ${REGISTRY_DOMAIN}/burmilla/os-dockercompose:1.27.4
+  image: ${REGISTRY_DOMAIN}/burmilla/os-dockercompose:1.28.0
   labels:
     io.rancher.os.scope: system
     io.rancher.os.after: console

--- a/images/10-docker-19.03.15/Dockerfile
+++ b/images/10-docker-19.03.15/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-19.03.15/prebuild.sh
+++ b/images/10-docker-19.03.15/prebuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "amd64" ]; then
+    DOCKERARCH="x86_64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-19.03.15_arm64/Dockerfile
+++ b/images/10-docker-19.03.15_arm64/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-19.03.15_arm64/prebuild.sh
+++ b/images/10-docker-19.03.15_arm64/prebuild.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "arm64" ]; then
+    DOCKERARCH="aarch64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+    SUFFIX="_${ARCH}"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-20.10.3/Dockerfile
+++ b/images/10-docker-20.10.3/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-20.10.3/prebuild.sh
+++ b/images/10-docker-20.10.3/prebuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "amd64" ]; then
+    DOCKERARCH="x86_64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-20.10.3_arm64/Dockerfile
+++ b/images/10-docker-20.10.3_arm64/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-20.10.3_arm64/prebuild.sh
+++ b/images/10-docker-20.10.3_arm64/prebuild.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "arm64" ]; then
+    DOCKERARCH="aarch64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+    SUFFIX="_${ARCH}"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/index.yml
+++ b/index.yml
@@ -19,6 +19,8 @@ services:
 engines:
 - docker-19.03.13
 - docker-19.03.14
+- docker-19.03.15
 - docker-20.10.0
 - docker-20.10.1
 - docker-20.10.2
+- docker-20.10.3


### PR DESCRIPTION
I will publish v1.9.1 soon which defaults to 19.03.15 but let's make those available for v1.9.0 too (on v1.9.1-rc1 they are already I tested that those works).

https://docs.docker.com/engine/release-notes/19.03/#190315
https://docs.docker.com/engine/release-notes/#20103