### PR TITLE
Bump up docker-compose to 1.28.6

### DIFF
--- a/d/docker-compose.yml
+++ b/d/docker-compose.yml
@@ -1,5 +1,5 @@
 docker-compose:
-  image: ${REGISTRY_DOMAIN}/burmilla/os-dockercompose:1.28.4
+  image: ${REGISTRY_DOMAIN}/burmilla/os-dockercompose:1.28.6
   labels:
     io.rancher.os.scope: system
     io.rancher.os.after: console


### PR DESCRIPTION
Bumps up docker-compose to [1.28.6](https://github.com/docker/compose/releases/tag/1.28.6).