### PR TITLE
Update virtualbox-tools kernel version to match burmilla/os.

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,8 +1,15 @@
 FROM ubuntu:bionic
 # FROM arm64=arm64v8/ubuntu:bionic
 
-RUN apt-get update && \
-    apt-get install -y curl git wget unzip
+ARG APT_ARCHIVE_SOURCE="archive.ubuntu.com"
+
+RUN sed -i "s|archive.ubuntu.com|${APT_ARCHIVE_SOURCE}|" /etc/apt/sources.list \
+ && apt-get update \
+ && apt-get install -y \
+      curl \
+      git \
+      wget \
+      unzip
 
 ENV DAPPER_ENV VERSION DEV_BUILD
 ENV DAPPER_DOCKER_SOCKET true

--- a/images/10-hypervvmtools/Dockerfile
+++ b/images/10-hypervvmtools/Dockerfile
@@ -1,12 +1,13 @@
-FROM gcc:7.4.0 as build-essential
+FROM gcc:10.3.0 as build-essential
 # FROM arm64=skip arm=skip
+
 #RUN apt-get update && \
 #    apt-get install -y --no-install-recommends kmod && \
 #    apt-get clean && \
 #    rm -rf /var/lib/apt/* \
 
 WORKDIR /dist
-ENV KERNEL_VERSION 4.14.206-burmilla
+ENV KERNEL_VERSION 4.14.229-burmilla
 ENV KERNEL_SRC https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86-src.tgz
 
 RUN wget -q $KERNEL_SRC && \

--- a/images/10-vboxtools/Dockerfile
+++ b/images/10-vboxtools/Dockerfile
@@ -1,38 +1,53 @@
-FROM gcc:7.4.0 as build-essential
-ENV KERNEL_VERSION 4.14.206-burmilla
+FROM gcc:10.3.0 as build-essential
+
+ENV KERNEL_VERSION 5.10.28-burmilla
 
 ENV KERNEL_HEADERS https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/build-linux-${KERNEL_VERSION}-x86.tar.gz
 ENV KERNEL_BASE https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
-ENV VBOX_VERSION 6.1.16
-ENV VBOX_SHA256 88db771a5efd7c048228e5c1e0b8fba56542e9d8c1b75f7af5b0c4cf334f0584
+ENV VBOX_VERSION 6.1.22
+ENV VBOX_SHA256 bffc316a7b8d5ed56d830e9f6aef02b4e5ffc28674032142e96ffbedd905f8c9
 
-RUN apt-get update; \
-	apt-get install -y --no-install-recommends p7zip-full libelf-dev; \
-	apt-get clean; \
-	rm -rf /var/lib/apt/*
-RUN mkdir -p /usr/src/v${KERNEL_VERSION}; \
-	curl -sfL ${KERNEL_BASE} | tar zxf - -C /; \
-	curl -sfL ${KERNEL_HEADERS} | tar zxf - -C /usr/src/v${KERNEL_VERSION}
-RUN wget -O /vbox.iso "https://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso"; \
-	echo "$VBOX_SHA256 */vbox.iso" | sha256sum -c -; \
-	7z x -o/ /vbox.iso VBoxLinuxAdditions.run; \
-	rm /vbox.iso; \
-	sh /VBoxLinuxAdditions.run --noexec --target /usr/src/vbox; \
-	mkdir /usr/src/vbox/amd64; \
-	7z x -so /usr/src/vbox/VBoxGuestAdditions-amd64.tar.bz2 | tar --extract --directory /usr/src/vbox/amd64; \
-	rm /usr/src/vbox/VBoxGuestAdditions-*.tar.bz2; \
-	ln -sT "vboxguest-$VBOX_VERSION" /usr/src/vbox/amd64/src/vboxguest
-RUN make -C /usr/src/vbox/amd64/src/vboxguest -j "$(nproc)" \
-	KERN_DIR='/lib/modules/${KERNEL_VERSION}/build' \
-	KERN_VER=${KERNEL_VERSION} \
-	vboxguest vboxsf 
+RUN set -x \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends p7zip-full libelf-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/*
+
+RUN set -x \
+ && mkdir -p /usr/src/v${KERNEL_VERSION} \
+ && curl -sfL ${KERNEL_BASE} | tar zxf - -C / \
+ && curl -sfL ${KERNEL_HEADERS} | tar zxf - -C /usr/src/v${KERNEL_VERSION}
+
+RUN set -x \
+ && wget -nv -O /vbox.iso "https://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso" \
+ && echo "${VBOX_SHA256} */vbox.iso" | sha256sum -c - \
+ && 7z x -o/ /vbox.iso VBoxLinuxAdditions.run \
+ && rm /vbox.iso \
+ && sh /VBoxLinuxAdditions.run --noexec --target /usr/src/vbox \
+ && mkdir /usr/src/vbox/amd64 \
+ && 7z x -so /usr/src/vbox/VBoxGuestAdditions-amd64.tar.bz2 | tar --extract --directory /usr/src/vbox/amd64 \
+ && rm /usr/src/vbox/VBoxGuestAdditions-*.tar.bz2 \
+ && ln -sT "vboxguest-$VBOX_VERSION" /usr/src/vbox/amd64/src/vboxguest
+
+RUN set -x \
+ && make \
+      -C /usr/src/vbox/amd64/src/vboxguest \
+      -j "$(nproc)" \
+      KERN_DIR="/lib/modules/${KERNEL_VERSION}/build" \
+      KERN_VER="${KERNEL_VERSION}" \
+      vboxguest vboxsf
+
 
 FROM debian:stable-slim
+
 WORKDIR /dist
-RUN apt-get update; \
-        apt-get install -y --no-install-recommends kmod; \
-        apt-get clean; \
-        rm -rf /var/lib/apt/*
+
+RUN set -x \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends kmod \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/*
+
 COPY run /usr/local/bin/
 COPY --from=build-essential /usr/src/vbox/amd64/src/vboxguest/vboxguest.ko .
 COPY --from=build-essential /usr/src/vbox/amd64/src/vboxguest/vboxsf.ko .

--- a/v/virtualbox-tools.yml
+++ b/v/virtualbox-tools.yml
@@ -1,5 +1,5 @@
 virtualbox-tools:
-  image: ${REGISTRY_DOMAIN}/burmilla/os-vboxtools:v6.1.16-4.14.206-burmilla
+  image: ${REGISTRY_DOMAIN}/burmilla/os-vboxtools:v6.1.22-5.10.28-burmilla
   command: /usr/local/bin/run
   privileged: true
   restart: always


### PR DESCRIPTION
 * Add support for ubuntu archive mirror.
 * Bump compiler version for `hypervvmtools` and `virtualbox-tools` due to lack of `asm_inline` support required by newer kernels.
 * Bump virtualbox version as newer kernels require `>=6.1.18`.
 * Changed `os-vboxtools` image tag. (new `os-services` image should be pushed to dockerhub)