### PR TITLE
Add HBM Docker authorization plugin

### DIFF
--- a/h/hbm.yml
+++ b/h/hbm.yml
@@ -1,0 +1,16 @@
+hbm:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-hbm:burmilla.cf3c5c0
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: network
+    io.rancher.os.before: docker
+  pid: host
+  ipc: host
+  net: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes:
+    - /etc/docker:/etc/docker
+    - /var/run/docker:/var/run/docker
+    - /opt/hbm/data:/var/lib/hbm

--- a/index.yml
+++ b/index.yml
@@ -16,6 +16,7 @@ services:
 - waagent
 - docker-compose
 - azure-identity
+- hbm
 engines:
 - docker-24.0.9
 - docker-25.0.3


### PR DESCRIPTION
Add updated version for HBM plugin from [here](https://github.com/jonasbroms/hbm) so there is no need to create custom service anymore like described in https://github.com/burmilla/hbm/blob/master/docs/installation/linux/rancheros.md

Needs:
* `--authorization-plugin=hbm` flag for Docker engine.
* TLS based configuration for Docker engine instead of docker.sock, other why user detection does not work.
  * Look unit test example https://github.com/burmilla/hbm/blob/71ab9bef9a9a5c0cc84bb6354b1d050db07539c2/scripts/run-test#L109-L114