### PR TITLE
Add Docker 20.10.27 and 23.0.10

### DIFF
--- a/d/docker-20.10.27.yml
+++ b/d/docker-20.10.27.yml
@@ -1,0 +1,21 @@
+docker:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-docker:20.10.27${SUFFIX}
+  command: ros user-docker
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  net: host
+  pid: host
+  ipc: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes_from:
+  - all-volumes
+  volumes:
+  - /sys:/host/sys
+  - /var/lib/system-docker:/var/lib/system-docker:shared

--- a/d/docker-23.0.10.yml
+++ b/d/docker-23.0.10.yml
@@ -1,0 +1,21 @@
+docker:
+  image: ${REGISTRY_DOMAIN}/burmilla/os-docker:23.0.10${SUFFIX}
+  command: ros user-docker
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  net: host
+  pid: host
+  ipc: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes_from:
+  - all-volumes
+  volumes:
+  - /sys:/host/sys
+  - /var/lib/system-docker:/var/lib/system-docker:shared

--- a/images/10-docker-20.10.27/Dockerfile
+++ b/images/10-docker-20.10.27/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-20.10.27/prebuild.sh
+++ b/images/10-docker-20.10.27/prebuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "amd64" ]; then
+    DOCKERARCH="x86_64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/images/10-docker-23.0.10/Dockerfile
+++ b/images/10-docker-23.0.10/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-23.0.10/prebuild.sh
+++ b/images/10-docker-23.0.10/prebuild.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+VERSION=$1
+ARCH=$2
+if [ "$ARCH" == "amd64" ]; then
+    DOCKERARCH="x86_64"
+    URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-${VERSION}.tgz"
+    #ROOTLESS_URL="https://download.docker.com/linux/static/stable/${DOCKERARCH}/docker-rootless-extras-${VERSION}.tgz"
+    COMPLETION_URL="https://raw.githubusercontent.com/docker/cli/v${VERSION}/contrib/completion/bash/docker"
+fi
+
+DEST="./images/10-docker-${VERSION}${SUFFIX}"
+
+mkdir -p $DEST
+curl -sL ${URL} | tar xzf - -C $DEST
+#curl -sL ${ROOTLESS_URL} | tar xzf - -C $DEST
+curl -sL -o $DEST/docker/completion ${COMPLETION_URL}
+mv $DEST/docker $DEST/engine
+#mv $DEST/docker-rootless-extras/* $DEST/engine

--- a/index.yml
+++ b/index.yml
@@ -17,5 +17,7 @@ services:
 - docker-compose
 - azure-identity
 engines:
+- docker-20.10.27
+- docker-23.0.10
 - docker-24.0.9
 - docker-25.0.3


### PR DESCRIPTION
Add Docker 20.10.27 and 23.0.10 to list.

These versions are not anymore supported/recommended but might be useful in certain upgrade scenarios.